### PR TITLE
Changed sysfont to handle font collisions

### DIFF
--- a/src_py/sysfont.py
+++ b/src_py/sysfont.py
@@ -104,19 +104,29 @@ def _parse_font_entry_win(name, font, fonts):
     mods = ("demibold", "narrow", "light", "unicode", "bt", "mt")
     if name.endswith(true_type_suffix):
         name = name.rstrip(true_type_suffix).rstrip()
-    name = name.lower().split()
+    name = name.lower().replace('-', ' ').replace('_', ' ').split()
     bold = italic = False
-    for mod in mods:
-        if mod in name:
-            name.remove(mod)
     if "bold" in name:
         name.remove("bold")
         bold = True
     if "italic" in name:
         name.remove("italic")
         italic = True
+    if "regular" in name:
+        name.remove("regular")
+    full_name = name.copy()
+    for mod in mods:
+        if mod in name:
+            name.remove(mod)
+
     name = "".join(name)
     name = _simplename(name)
+    full_name = "".join(full_name)
+    full_name = _simplename(full_name)
+
+    # In the event of a collision, opt for the font's full name instead
+    if name in fonts:
+        name = full_name
 
     _addfont(name, bold, italic, font, fonts)
 


### PR DESCRIPTION
## Issue Addressed
#4324

## PR Summary
This PR changes `_parse_font_entry_win()`  to fix the aforementioned issue. From my observations and testing, the regular variant of a font is the first to be parsed, and any style variations will follow. In the original function, this would mean the most recently parsed variation would be the default instead of the regular variation, which is undesired.

To fix this, the modified function now checks if the stripped name (with all its modifiers removed) already exists in the font dictionary. If it does, it means the regular variation has already been parsed, so the function will insert the font with its full name instead (which has the modifiers). This allows users to select regular or modified fonts at their will. The function will also strip the word 'regular' from font names, which fixes the issue for fonts like Lucida Fax.

Finally, I have changed the preprocessing done to the font's name before `split()`, as some fonts do not use whitespace in their names, so they may not be processed properly.

### Examples
(Using the example code from the issue.)

```python
f = pg.font.SysFont('Arial', 48)
```
<img src="https://github.com/user-attachments/assets/efef205b-1c4b-43b3-81dc-af489dd35875" width="500" />

```python
f = pg.font.SysFont('Arial Narrow', 48)
```
<img src="https://github.com/user-attachments/assets/93dadd6d-3903-46fd-bbea-ba04396b78b4" width="500" />

```python
f = pg.font.SysFont('Lucida Fax', 48)
```
<img src="https://github.com/user-attachments/assets/fa2663cb-54e8-4057-9437-003635aa2578" width="500" />

```python
f = pg.font.SysFont('Lucida Fax Demibold', 48)
```
<img src="https://github.com/user-attachments/assets/3e2eac59-e111-49fe-9b49-fdd062b230c5" width="500" />
